### PR TITLE
String trim fix for missing final character

### DIFF
--- a/InvariantDisks/IDSerialLinker.cpp
+++ b/InvariantDisks/IDSerialLinker.cpp
@@ -53,7 +53,7 @@ namespace ID
 		size_t first = s.find_first_not_of(' ');
 		size_t last = s.find_last_not_of(' ');
 		if (first != std::string::npos)
-			return s.substr(first, last - first);
+			return s.substr(first, last - first + 1);
 		return s;
 	}
 


### PR DESCRIPTION
This fixes the off-by-one error reported by ununnilium in the forum.

The final character of model and the final character of serial number
were being deleted. For instance,

Model:          WDC WD30EFRX-68EUZN0
Serial Number:  WD-WMC4N0H2JLJP

should become WDC_WD30EFRX-68EUZN0-WD-WMC4N0H2JLJP not
WDC_WD30EFRX-68EUZN-WD-WMC4N0H2JLJ.
